### PR TITLE
Automaticall mapping dependencies in Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ HDF5/
 environment
 __pycache__/
 testsuite/tests/
+.deps.mk
+Prog/.echo_compile_mods
+Prog/.parse_parameters

--- a/Analysis/Makefile
+++ b/Analysis/Makefile
@@ -1,23 +1,38 @@
 .PHONY : all tidy clean
+
+SRCS = Max_SAC.F90 \
+	ana.F90 \
+	ana_hdf5.F90 \
+	ana_mod.F90 \
+	convert_latt.F90 \
+	convert_local.F90 \
+	convert_scal.F90 \
+	cov_eq.F90 \
+	cov_mut.F90 \
+	cov_scal.F90 \
+	cov_tau.F90 \
+	maxent_wrapper_mod.F90
+
 BINS= cov_scal.out cov_tau.out cov_tau_ph.out Max_SAC.out cov_eq.out cov_mut.out ana.out
 BINS_H5=ana_hdf5.out convert_scal.out convert_latt.out convert_local.out
-OBJS= cov_scal.o   cov_tau.o   cov_tau_ph.o   Max_SAC.o   cov_eq.o   cov_mut.o   ana.o ana_hdf5.o
 OBJS1=Predefined_Latt_mod.o ana_mod.o maxent_wrapper_mod.o
-MODS=predefined_lattices.mod ana_mod.mod maxent_wrapper_mod.mod
 
+# Dependency helper variables
+DEPSFILE := .deps.mk
+DEPSGEN := ../Prog/gen_deps.py
 
-all: $(BINS)
-ifneq (,$(findstring DHDF5,$(ALF_FLAGS_ANA)))
-	@make $(BINS_H5)
-endif
+all: $(DEPSFILE) $(BINS) $(if $(findstring DHDF5,$(ALF_FLAGS_ANA)),$(BINS_H5))
 
-Predefined_Latt_mod.o: ../Prog/Predefined_Latt_mod.F90
-	$(ALF_FC) -c -o $@ $(ALF_FLAGS_ANA) $<
+# OBJS and MODS are auto-generated into $(DEPSFILE) by gen_deps.py
+-include $(DEPSFILE)
+ana_mod.o: Predefined_Latt_mod.o
+cov_eq.o: Predefined_Latt_mod.o
 
 cov_tau_ph.o: cov_tau.F90
 	$(ALF_FC) -c -o $@ $(ALF_FLAGS_ANA) -DPartHole $<
 
-Max_SAC.o: maxent_wrapper_mod.o
+Predefined_Latt_mod.o: ../Prog/Predefined_Latt_mod.F90
+	$(ALF_FC) -c -o $@ $(ALF_FLAGS_ANA) $<
 
 %.o: %.F90
 	$(ALF_FC) -c -o $@ $(ALF_FLAGS_ANA) $<
@@ -25,8 +40,11 @@ Max_SAC.o: maxent_wrapper_mod.o
 %.out: $(OBJS1) %.o
 	$(ALF_FC) -o $@ $^ $(ALF_LIB)
 
-tidy:
-	rm -f $(OBJS) $(OBJS1) $(MODS) cov_tau_ph.F90
+$(DEPSFILE): $(SRCS) $(DEPSGEN)
+	python3 $(DEPSGEN) $(SRCS) > $(DEPSFILE)
+
+tidy: $(DEPSFILE)
+	rm -f $(OBJS) cov_tau_ph.o $(MODS) $(DEPSFILE) Predefined_Latt_mod.o predefined_lattices.mod
 
 clean: tidy
 	rm -f $(BINS) $(BINS_H5)

--- a/Libraries/Modules/Makefile
+++ b/Libraries/Modules/Makefile
@@ -1,14 +1,40 @@
-LIB=modules_90.a
-OBJS=runtime_error_mod.o errors_mod.o files_mod.o   fourier_mod.o histograms_mod.o histograms_v2_mod.o lattices_v3_mod.o \
-	log_mesh_mod.o mymats_mod.o matrix_mod.o maxent_mod.o   maxent_stoch_mod.o   mpi_shared_mem_mod_v2.o \
-	natural_constants_mod.o precdef_mod.o random_wrap_mod.o Mat_subroutines_mod.o entanglement_mod.o   alf_hdf5_mod.o \
-	check_omp_num_threads_mod.o   iso8601_datetime_mod.o
-MODS=runtime_error_mod.mod errors.mod   files_mod.mod fourier.mod   histograms.mod   histograms_v2.mod   lattices_v3.mod   \
-	log_mesh.mod   mymats.mod   matrix.mod   maxent_mod.mod maxent_stoch_mod.mod mpi_shared_memory.mod \
-	natural_constants.mod   precdef.mod   random_wrap.mod   mat_subroutines.mod   entanglement_mod.mod alf_hdf5.mod \
-	check_omp_num_threads_mod.mod iso8601_datetime_mod.mod
+.PHONY : lib clean
 
-$(LIB): $(OBJS)
+LIB=modules_90.a
+
+SRCS = Mat_subroutines_mod.F90 \
+	alf_hdf5_mod.F90 \
+	check_omp_num_threads_mod.F90 \
+	entanglement_mod.F90 \
+	errors_mod.F90 \
+	files_mod.F90 \
+	fourier_mod.F90 \
+	histograms_mod.F90 \
+	histograms_v2_mod.F90 \
+	iso8601_datetime_mod.F90 \
+	lattices_interface_mod.F90 \
+	lattices_v3_mod.F90 \
+	log_mesh_mod.F90 \
+	matrix_mod.F90 \
+	maxent_mod.F90 \
+	maxent_stoch_mod.F90 \
+	mpi_shared_mem_mod_v2.F90 \
+	mymats_mod.F90 \
+	natural_constants_mod.F90 \
+	precdef_mod.F90 \
+	random_wrap_mod.F90 \
+	runtime_error_mod.F90
+
+# Dependency helper variables
+DEPSFILE := .deps.mk
+DEPSGEN := ../../Prog/gen_deps.py
+
+lib: $(LIB)
+
+# OBJS and MODS are auto-generated into $(DEPSFILE) by gen_deps.py
+-include $(DEPSFILE)
+
+$(LIB): $(DEPSFILE) $(OBJS)
 	ar -r $(LIB) $(OBJS)
 
 lattices_x86-64.so: runtime_error_mod.F90 lattices_interface_mod.F90 matrix_mod.F90 lattices_v3_mod.F90
@@ -30,19 +56,11 @@ lattices_armv8.4-a.so: runtime_error_mod.F90 lattices_interface_mod.F90 matrix_m
 %.o: %.F90
 	$(ALF_FC) -c $(ALF_FLAGS_MODULES) $<
 
-alf_hdf5_mod.o: runtime_error_mod.o
-errors_mod.o: runtime_error_mod.o mymats_mod.o random_wrap_mod.o
-fourier_mod.o: runtime_error_mod.o maxent_mod.o maxent_stoch_mod.o matrix_mod.o
-lattices_v3_mod.o: runtime_error_mod.o mymats_mod.o 
-maxent_mod.o: mymats_mod.o errors_mod.o runtime_error_mod.o
-histograms_v2_mod.o: log_mesh_mod.o
-log_mesh_mod.o: runtime_error_mod.o
-mat_subroutines.o: runtime_error_mod.o
-mpi_shared_mem_mod_v2.o: runtime_error_mod.o
-mymats.o: runtime_error_mod.o
+$(DEPSFILE): $(SRCS) $(DEPSGEN)
+	python3 $(DEPSGEN) $(SRCS) > $(DEPSFILE)
 
-clean:
-	rm -f $(OBJS) $(MODS) $(LIB)
+clean: $(DEPSFILE)
+	rm -f $(OBJS) $(MODS) $(LIB) $(DEPSFILE)
 
 #unused modules: histograms histograms_v2 log_mesh natural_constants
 #unused, except for in Prog/FFA_Orginals/: precdef

--- a/Prog/Makefile
+++ b/Prog/Makefile
@@ -1,51 +1,77 @@
-.PHONY : Compile tidy clean program parse_parameters echo_compile_mods git.h
+.PHONY : Compile tidy clean program
 
-OHAM = `./parse_ham.py --print_obj_list`
+# Source files (single source of truth; OBJS and MODS are generated into DEPSFILE)
+SRCS = Hamiltonians/LRC_mod.F90 control_mod.F90 Fields_mod.F90 Operator_mod.F90 WaveFunction_mod.F90 observables_mod.F90 \
+	ContainerElementBase_mod.F90 DynamicMatrixArray_mod.F90 OpTTypes_mod.F90 OpT_time_dependent.F90 \
+	Hamiltonian_main_mod.F90 QDRP_decompose_mod.F90 udv_state_mod.F90 Hop_mod.F90 UDV_WRAP_mod.F90 \
+	Predefined_Int_mod.F90 Predefined_Obs_mod.F90 Predefined_Latt_mod.F90 Predefined_Hop_mod.F90 Predefined_Trial_mod.F90 \
+	wrapul_mod.F90 cgr1_mod.F90 wrapur_mod.F90 cgr2_2_mod.F90 upgrade_mod.F90 Set_random_mod.F90 \
+	Global_mod.F90 Langevin_HMC_mod.F90 Wrapgr_mod.F90 tau_m_mod.F90 tau_p_mod.F90 QMC_runtime_var_mod.F90 \
+	main.F90
 
-OBJS = Hamiltonians/LRC_mod.o control_mod.o Fields_mod.o Operator_mod.o WaveFunction_mod.o observables_mod.o \
-	ContainerElementBase_mod.o DynamicMatrixArray_mod.o OpTTypes_mod.o OpT_time_dependent.o \
-	Hamiltonian_main_mod.o QDRP_decompose_mod.o udv_state_mod.o Hop_mod.o UDV_WRAP_mod.o \
-	Predefined_Int_mod.o Predefined_Obs_mod.o Predefined_Latt_mod.o Predefined_Hop_mod.o  Predefined_Trial_mod.o \
-	wrapul_mod.o   cgr1_mod.o   wrapur_mod.o   cgr2_2_mod.o   upgrade_mod.o   Set_random_mod.o \
-	Global_mod.o Langevin_HMC_mod.o Wrapgr_mod.o tau_m_mod.o tau_p_mod.o QMC_runtime_var_mod.o \
-	main.o
+# Dependency helper variables
+DEPSFILE := .deps.mk
+DEPSGEN := ./gen_deps.py
+HAM_LIST_D := $(wildcard Hamiltonians.list.d/*)
 
-MODS = control.mod fields_mod.mod global_mod.mod hop_mod.mod lrc_mod.mod observables.mod \
-	operator_mod.mod predefined_int.mod predefined_lattices.mod predefined_obs.mod \
-	predefined_hoppings.mod  predefined_trial.mod qdrp_mod.mod QMC_runtime_var_mod.mod tau_m_mod.mod tau_p_mod.mod \
-	udv_state_mod.mod udv_wrap_mod.mod wavefunction_mod.mod wrapgr_mod.mod hamiltonian.mod \
-	opt_time_dependent.mod containerelementbase_mod.mod opttypes_mod.mod dynamicmatrixarray_mod.mod langevin_hmc_mod.mod \
-	wrapul_mod.mod cgr1_mod.mod wrapur_mod.mod cgr2_2_mod.mod upgrade_mod.mod set_random.mod
+all: program
 
-program: git.h parse_parameters echo_compile_mods $(OBJS)
-	make $(OHAM)
+# OBJS and MODS are auto-generated into $(DEPSFILE) by gen_deps.py
+-include $(DEPSFILE)
+
+program: ALF.out
+
+ALF.out: $(DEPSFILE) $(OBJS)
 	@echo "Link program"
-	$(ALF_FC) -o "ALF.out" $(OBJS) $(OHAM) $(ALF_LIB)
+	$(ALF_FC) -o "ALF.out" $(OBJS) $(ALF_LIB)
+
+OHAM := $(shell ./parse_ham.py --print_obj_list 2>/dev/null)
 
 Hamiltonian_main_mod.o: Hamiltonians_interface.h Hamiltonians_case.h
 
-git.h:
+$(OHAM): .parse_parameters Hamiltonian_main_mod.o
+
+main.o: git.h
+
+# Regenerate git.h whenever the commit hash, branch, or dirty state changes.
+# .git/HEAD changes on branch switch; .git/index changes on commit/stage.
+# $(SRCS) catches unstaged modifications that flip the -dirty suffix.
+git.h: $(wildcard ../.git/HEAD ../.git/index) $(SRCS)
 	./Git_config.sh
 
-parse_parameters:
+.parse_parameters: Hamiltonians.list $(HAM_LIST_D)
 	@echo "Parsing Hamiltonian parameters"
 	./parse_ham.py --create_read_write_par
+	@touch $@
 
-Hamiltonians_interface.h:
+Hamiltonians_interface.h: Hamiltonians.list $(HAM_LIST_D)
 	./parse_ham.py --create_hamiltonians_interface
 
-Hamiltonians_case.h:
+Hamiltonians_case.h: Hamiltonians.list $(HAM_LIST_D)
 	./parse_ham.py --create_hamiltonians_case
 
-%.o: %.F90
-	$(ALF_FC) -c -o $@ $(ALF_FLAGS_PROG) $<
+# The order-only prerequisite (after |) guarantees .echo_compile_mods is built
+# before any .o file under parallel make (-j N), so the banner appears first.
+# Because it is order-only, Make never timestamps .echo_compile_mods against
+# the .o files, so it never triggers recompilation.
+%.o: %.F90 | .echo_compile_mods
+	$(ALF_FC) -c $(ALF_FLAGS_PROG) -o $@ $<
 
-tidy:
-	rm -f $(OBJS) $(OHAM) $(MODS) hamiltonian*.mod hamiltonian*.smod
-	rm -f git.h Hamiltonians_interface.h Hamiltonians_case.h Hamiltonians/Hamiltonian_*_read_write_parameters.F90
+# Generate dependency file that maps object files to the object(s) providing
+# the Fortran modules they USE. This enables correct parallel builds.
+$(DEPSFILE): $(SRCS) $(DEPSGEN) Hamiltonians.list $(HAM_LIST_D) $(shell ./parse_ham.py --print_src_list)
+	python3 $(DEPSGEN) $(SRCS) $(shell ./parse_ham.py --print_src_list) > $(DEPSFILE)
+
+tidy: $(DEPSFILE)
+	rm -f $(OBJS) $(OHAM) $(MODS) hamiltonian*.mod hamiltonian*.smod $(DEPSFILE) .echo_compile_mods
+	rm -f git.h .parse_parameters Hamiltonians_interface.h Hamiltonians_case.h Hamiltonians/Hamiltonian_*_read_write_parameters.F90
 
 clean: tidy
 	rm -f "ALF.out"
 
-echo_compile_mods:
+# Stamp file: printed once when the dependency file is (re-)generated, then
+# touched so Make can track whether the echo has already fired.  Deleted by
+# tidy/clean so the banner reappears on the next fresh build.
+.echo_compile_mods: $(DEPSFILE)
 	@echo "Compiling program modules"
+	@touch $@

--- a/Prog/gen_deps.py
+++ b/Prog/gen_deps.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Generate Fortran module dependency information for Make.
+
+Given a list of .F90 source files, scan for:
+- provided modules ("module <name>")
+- used modules ("use [,...] :: <name>" or "use <name>")
+
+Output make-style variable definitions and dependency rules:
+  OBJS = path/to/file1.o path/to/file2.o ...
+  MODS = module1.mod module2.mod ...
+  path/to/target.o: path/to/provider.o
+so that object files depending on modules build after the objects that provide them.
+
+Notes:
+- Ignores "module procedure", "end module", and "submodule" statements.
+- Basic handling of line continuations with '&'.
+- Case-insensitive parsing; emitted file paths retain original case.
+"""
+from __future__ import annotations
+import os
+import re
+import sys
+from typing import Dict, List, Set, Tuple
+
+USE_RE_1 = re.compile(r"^\s*use\s*[,\s][^:]*::\s*([a-zA-Z0-9_]+)", re.IGNORECASE)
+USE_RE_2 = re.compile(r"^\s*use\s+([a-zA-Z0-9_]+)", re.IGNORECASE)
+MOD_RE = re.compile(r"^\s*module\s+([a-zA-Z0-9_]+)\b", re.IGNORECASE)
+SUBMOD_RE = re.compile(r"^\s*submodule\b", re.IGNORECASE)
+ENDMOD_RE = re.compile(r"^\s*end\s*module\b", re.IGNORECASE)
+MODPROC_RE = re.compile(r"^\s*module\s+procedure\b", re.IGNORECASE)
+
+
+def read_statements(path: str) -> List[str]:
+    stmts: List[str] = []
+    buf: str = ""
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for raw in f:
+                # strip comments
+                line = re.sub(r"!.*", "", raw)
+                if not line.strip():
+                    continue
+                # handle continuations
+                s = line.rstrip().strip()
+                if buf:
+                    s = (buf + " " + s).strip()
+                if s.endswith("&"):
+                    buf = s[:-1].strip()
+                    continue
+                if s.startswith("&"):
+                    # continuation from previous (unlikely after above), keep
+                    s = s[1:].strip()
+                    if buf:
+                        s = (buf + " " + s).strip()
+                stmts.append(s)
+                buf = ""
+        if buf:
+            stmts.append(buf)
+    except FileNotFoundError:
+        pass
+    return stmts
+
+
+def to_obj(path: str) -> str:
+    return os.path.splitext(path)[0] + ".o"
+
+
+def to_src(path: str) -> str:
+    """Normalize a path that may end in .o or .F90 to its .F90 source form."""
+    return os.path.splitext(path)[0] + ".F90"
+
+
+def discover_modules_and_uses(srcs: List[str]):
+    provides: Dict[str, Set[str]] = {}
+    uses_by_src: Dict[str, Set[str]] = {}
+
+    for src in srcs:
+        stmts = read_statements(src)
+        uses: Set[str] = set()
+        for st in stmts:
+            st_l = st.lower()
+            if SUBMOD_RE.match(st_l):
+                continue
+            if ENDMOD_RE.match(st_l):
+                continue
+            if MODPROC_RE.match(st_l):
+                continue
+            # provided module
+            m = MOD_RE.match(st_l)
+            if m:
+                modname = m.group(1).lower()
+                provides.setdefault(modname, set()).add(src)
+                continue
+            # use statements
+            m1 = USE_RE_1.match(st_l)
+            if m1:
+                uses.add(m1.group(1).lower())
+                continue
+            m2 = USE_RE_2.match(st_l)
+            if m2:
+                uses.add(m2.group(1).lower())
+                continue
+        if uses:
+            uses_by_src[src] = uses
+    return provides, uses_by_src
+
+
+def fmt_make_var(name: str, values: List[str], indent: str = "\t") -> str:
+    """Format a Make variable assignment with continuation lines."""
+    if not values:
+        return f"{name} ="
+    lines = [f"{name} = {values[0]}"]
+    for v in values[1:]:
+        lines[-1] += " \\"
+        lines.append(f"{indent}{v}")
+    return "\n".join(lines)
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: gen_deps.py <file1.F90> [file2.F90 ...]", file=sys.stderr)
+        return 1
+    # Accept both .F90 and .o paths; normalize to .F90 for scanning
+    srcs = list(dict.fromkeys(to_src(a) for a in argv[1:]))
+    provides, uses_by_src = discover_modules_and_uses(srcs)
+
+    # OBJS: object files corresponding to the given sources
+    objs = [to_obj(s) for s in srcs]
+    print(fmt_make_var("OBJS", objs))
+    print()
+
+    # MODS: .mod files for all modules defined in the given sources
+    mods = sorted(f"{m}.mod" for m in provides)
+    print(fmt_make_var("MODS", mods))
+    print()
+
+    # Dependency rules
+    emitted: Set[Tuple[str, str]] = set()
+
+    for src, used_mods in uses_by_src.items():
+        for mod in sorted(used_mods):
+            provs = provides.get(mod)
+            if not provs:
+                # likely an intrinsic or external library module; ignore
+                continue
+            for prov_src in provs:
+                if prov_src == src:
+                    continue
+                dep = (to_obj(src), to_obj(prov_src))
+                if dep not in emitted:
+                    print(f"{dep[0]}: {dep[1]}")
+                    emitted.add(dep)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/Prog/parse_ham.py
+++ b/Prog/parse_ham.py
@@ -29,6 +29,11 @@ if __name__ == '__main__':
              '"Hamiltonians.list" and "Hamiltonians.list.d".'
         )
     parser.add_argument(
+        '--print_src_list', action='store_true',
+        help='Print list of Hamiltonian source files, derived from '
+             '"Hamiltonians.list" and "Hamiltonians.list.d".'
+        )
+    parser.add_argument(
         '--create_hamiltonians_interface', action='store_true',
         help='Create "Hamiltonians_interface.h", derived from '
              '"Hamiltonians.list" and "Hamiltonians.list.d".'
@@ -53,12 +58,15 @@ if __name__ == '__main__':
             print("Results:")
             pprint(parameters)
 
-    if (args.print_obj_list or args.create_hamiltonians_interface
+    if (args.print_obj_list or args.print_src_list or args.create_hamiltonians_interface
         or args.create_hamiltonians_case or args.create_read_write_par):
         ham_names, ham_files = get_ham_names_ham_files('Hamiltonians.list')
 
     if args.print_obj_list:
         print(' '.join([ham_file.replace('.F90', '.o') for ham_file in ham_files]))
+
+    if args.print_src_list:
+        print(' '.join(ham_files))
 
     if args.create_hamiltonians_interface:
         hamiltonians_interface_str = 'interface\n'

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.2)
 if(DEFINED ENV{ALF_FC})
   set(CMAKE_Fortran_COMPILER $ENV{ALF_FC})
 endif()

--- a/testsuite/Prog.tests/CMakeLists.txt
+++ b/testsuite/Prog.tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.2)
 Project(matmod.tests C Fortran)
 
 # add_executable(1-copy-sel-rows 1-copy-sel-rows.F90)

--- a/testsuite/matmod.tests/CMakeLists.txt
+++ b/testsuite/matmod.tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.2)
 Project(matmod.tests C Fortran)
 
 add_executable(1-diag-real-matrix 1-diag-real-matrix.F90)


### PR DESCRIPTION
This uses a Python script (that was generated with an LLM) to automatically map the dependencies between source files and generate object and module lists. In the Makefiles, instead of `OBJS` and `MODS` now only `SRCS` has to be specified, the rest is generated automatically.