### PR TITLE
627 ci pginvhpc runtime crash illegal instruction exit code 132 when executing progalfout

### DIFF
--- a/.github/workflows/tests-broad.yml
+++ b/.github/workflows/tests-broad.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: tests-broad-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/HDF5/install_hdf5.sh
+++ b/HDF5/install_hdf5.sh
@@ -59,7 +59,7 @@ export CC FC CXX
 printf "\033[0;32m=== Build with the following compilers C: %s, Fortran: %s, C++: %s \e[0m\n" "$CC" "$FC" "$CXX" 1>&2
 
 "$source_dir/configure" --prefix="$HDF5_DIR" --libdir="$HDF5_DIR/lib" \
-  --enable-fortran --enable-shared=no --enable-tests=no --enable-build-mode=clean --enable-optimization="-O3"
+  --enable-fortran --enable-shared=no --enable-tests=no --enable-build-mode=clean --enable-optimization="-O3" --enable-hl
 if ! make -j"$(nproc || sysctl -n hw.ncpu)"; then
   printf "\e[31m=== Compilation with compilers %s %s in directory %s failed ===\e[0m\n" "$CC" "$FC" "$PWD" 1>&2
   rm -rf "$HDF5_DIR"

--- a/HDF5/install_hdf5.sh
+++ b/HDF5/install_hdf5.sh
@@ -58,7 +58,8 @@ fi
 export CC FC CXX
 printf "\033[0;32m=== Build with the following compilers C: %s, Fortran: %s, C++: %s \e[0m\n" "$CC" "$FC" "$CXX" 1>&2
 
-"$source_dir/configure" --prefix="$HDF5_DIR" --libdir="$HDF5_DIR/lib" --enable-fortran --enable-shared=no --enable-tests=no
+"$source_dir/configure" --prefix="$HDF5_DIR" --libdir="$HDF5_DIR/lib" \
+  --enable-fortran --enable-shared=no --enable-tests=no --enable-build-mode=clean --enable-optimization="-O3"
 if ! make -j"$(nproc || sysctl -n hw.ncpu)"; then
   printf "\e[31m=== Compilation with compilers %s %s in directory %s failed ===\e[0m\n" "$CC" "$FC" "$PWD" 1>&2
   rm -rf "$HDF5_DIR"

--- a/configure.sh
+++ b/configure.sh
@@ -58,7 +58,7 @@ set_hdf5_flags()
   
   H5_major=1
   H5_minor=14
-  H5_patch=5
+  H5_patch=6
   H5_suff=""
   if [ -n "${ALF_HDF5_DIR+x}" ]; then
     printf "\nUsing custom HDF5 directory '%s'\n" "${ALF_HDF5_DIR}"


### PR DESCRIPTION
When compiling HDF5 with nvfortran, it defaults to hardware-dependant optimization flags (namely `-fast`), which can cause errors with e.g. the pre-compiled HDF5 binaries shipped with the images from https://github.com/ALF-QMC/alf-container. This pull request solves this by setting the optimization to -O3 in `HDF5/install_hdf5.sh`.

This pull request also updates HDF5 patch version from 1.14.5 to 1.14.6 and gives the workflow `test-broad.yml` a better concurrency group name.