### PR TITLE
Add environment variable for private hamiltonians.

### DIFF
--- a/Prog/parse_ham_mod.py
+++ b/Prog/parse_ham_mod.py
@@ -12,6 +12,7 @@ __copyright__ = "Copyright 2022, The ALF Project"
 __license__ = "GPL"
 
 import glob
+import os
 
 
 def get_ham_names_ham_files(ham_list_file):
@@ -20,8 +21,17 @@ def get_ham_names_ham_files(ham_list_file):
     Also parses files in directory `ham_list_file` + '.d',
     so usually ${ALF_DIR}/Prog/Hamiltonians.list and files in
     ${ALF_DIR}/Prog/Hamiltonians.list.d
+
+    If applicable, add any external Hamiltonians located at ${ALF_EXTRA_HAM_LIST}.
     """
     ham_list_files = [ham_list_file, *glob.glob(ham_list_file + '.d/*')]
+
+    extra = os.environ.get('ALF_EXTRA_HAM_LIST')
+    if extra:
+        if not os.path.isfile(extra):
+            raise FileNotFoundError(
+                'ALF_EXTRA_HAM_LIST is set but file not found: {}'.format(extra))
+        ham_list_files.append(extra)
 
     lines = []
     for file in ham_list_files:

--- a/Prog/parse_ham_mod.py
+++ b/Prog/parse_ham_mod.py
@@ -5,7 +5,6 @@ Includes functions for writing subroutines read_parameters() and
 write_parameters_hdf5().
 """
 # pylint: disable=invalid-name
-# pylint: disable=consider-using-f-string
 
 __author__ = "Jonas Schwab"
 __copyright__ = "Copyright 2022, The ALF Project"
@@ -25,22 +24,23 @@ def get_ham_names_ham_files(ham_list_file):
     If applicable, add any external Hamiltonians located at ${ALF_EXTRA_HAM_LIST}.
     """
 
-    d_dir = Path(ham_list_file + '.d')
-    ham_list_files = [ham_list_file, *(d_dir.glob('*') if d_dir.is_dir() else [])]
+    d_dir = Path(ham_list_file + ".d")
+    ham_list_files = [ham_list_file, *(d_dir.glob("*") if d_dir.is_dir() else [])]
 
-    extra = os.environ.get('ALF_EXTRA_HAM_LIST')
+    extra = os.environ.get("ALF_EXTRA_HAM_LIST")
     if extra:
         extra_path = Path(extra)
         if not extra_path.is_file():
             raise FileNotFoundError(
-                'ALF_EXTRA_HAM_LIST is set but file not found: {}'.format(extra))
+                f"ALF_EXTRA_HAM_LIST is set but file not found: {extra}"
+            )
         ham_list_files.append(extra_path)
 
     lines = []
     for file in ham_list_files:
-        with open(file, 'r', encoding='UTF-8') as f:
+        with open(file, "r", encoding="UTF-8") as f:
             for line in f.read().splitlines():
-                if not line.strip()[0] == '#':
+                if not line.strip()[0] == "#":
                     lines.append(line.strip().split())
 
     ham_names = []
@@ -50,8 +50,7 @@ def get_ham_names_ham_files(ham_list_file):
         try:
             ham_files.append(Path(os.path.expandvars(line[1])).resolve())
         except IndexError:
-            ham_files.append(
-                Path('Hamiltonians/Hamiltonian_{}_smod.F90'.format(line[0])).resolve())
+            ham_files.append(Path(f"Hamiltonians/Hamiltonian_{line[0]}_smod.F90").resolve())
     return ham_names, ham_files
 
 
@@ -63,28 +62,28 @@ def parse(filename):
     line as '#PARAMETERS START#' is the namelist name.
     """
     parameters = {}
-    with open(filename, 'r', encoding='UTF-8') as f:
+    with open(filename, "r", encoding="UTF-8") as f:
         lines = f.readlines()
 
     do_parse = False
     for i, line in enumerate(lines):
-        if '#PARAMETERS START#' in line:
+        if "#PARAMETERS START#" in line:
             do_parse = True
-            name_key = line.split('#PARAMETERS START#')[1].strip()
+            name_key = line.split("#PARAMETERS START#")[1].strip()
             if not name_key.isidentifier():
                 raise Exception(
-                    'In line {} of {}: '.format(i+1, filename) +
-                    '"{}" is not a valid namelist name.'.format(name_key)
-                    )
+                    f'In line {i + 1} of {filename}: '
+                    f'"{name_key}" is not a valid namelist name.'
+                )
             namelist = {}
             parameters[name_key] = namelist
             continue
-        if '#PARAMETERS END#' in line:
+        if "#PARAMETERS END#" in line:
             do_parse = False
             continue
-        if do_parse and '::' in line:
+        if do_parse and "::" in line:
             par = parse_line(line)
-            par_name = par.pop('name')
+            par_name = par.pop("name")
             namelist[par_name] = par
     return parameters
 
@@ -92,26 +91,26 @@ def parse(filename):
 def parse_line(line):
     """Parse single line in Fortran file for parameter."""
     parameter = {}
-    dtype, rest = line.split('::', maxsplit=1)
+    dtype, rest = line.split("::", maxsplit=1)
     dtype = dtype.strip().lower()
-    if '!' in rest:
-        assignment, comment = rest.strip().split('!', maxsplit=1)
+    if "!" in rest:
+        assignment, comment = rest.strip().split("!", maxsplit=1)
         assignment = assignment.strip()
-        parameter['comment'] = comment.strip(' !')
+        parameter["comment"] = comment.strip(" !")
     else:
         assignment = rest.strip()
-        parameter['comment'] = ''
-    name, value = assignment.split('=')
+        parameter["comment"] = ""
+    name, value = assignment.split("=")
     # parameter['name'] = name.split('(')[0].strip()
-    parameter['name'] = name.strip()
+    parameter["name"] = name.strip()
     value = value.strip()
-    parameter['defined_in_base'] = dtype.startswith('!')
-    if '[' in value:
-        parameter['value'] = []
-        for val in value.strip('[]').split(','):
-            parameter['value'].append(_to_value(dtype, val))
+    parameter["defined_in_base"] = dtype.startswith("!")
+    if "[" in value:
+        parameter["value"] = []
+        for val in value.strip("[]").split(","):
+            parameter["value"].append(_to_value(dtype, val))
     else:
-        parameter['value'] = _to_value(dtype, value)
+        parameter["value"] = _to_value(dtype, value)
 
     return parameter
 
@@ -124,15 +123,15 @@ def _dtype_name(parameter):
     if isinstance(parameter, list):
         return _dtype_name(parameter[0])
     if isinstance(parameter, bool):
-        return 'logical'
+        return "logical"
     if isinstance(parameter, float):
-        return 'real(dp)'
+        return "real(dp)"
     # if isinstance(parameter, complex):
     #     return 'complex(dp)'
     if isinstance(parameter, int):
-        return 'integer'
+        return "integer"
     if isinstance(parameter, str):
-        return 'Character(len=64)'
+        return "Character(len=64)"
     raise Exception('Error in "_dtype_name": unrecognized type')
 
 
@@ -142,29 +141,29 @@ def _convert_par_to_str(parameter):
     """
     if isinstance(parameter, list):
         pars = [_convert_par_to_str(p) for p in parameter]
-        return '[{}]'.format(', '.join(pars))
+        return f"[{', '.join(pars)}]"
     if isinstance(parameter, bool):
         if parameter:
-            return '.true.'
-        return '.false.'
+            return ".true."
+        return ".false."
     if isinstance(parameter, float):
-        if 'e' in '{}'.format(parameter):
-            return '{}'.format(parameter).replace('e', 'd')
-        return '{}d0'.format(parameter)
+        if "e" in f"{parameter}":
+            return f"{parameter}".replace("e", "d")
+        return f"{parameter}d0"
     # if isinstance(parameter, complex):
     #     return '({}, {})'.format(_convert_par_to_str(parameter.real),
     #                              _convert_par_to_str(parameter.imag))
     if isinstance(parameter, int):
-        return '{}'.format(parameter)
+        return f"{parameter}"
     if isinstance(parameter, str):
-        return '"{}"'.format(parameter)
+        return f'"{parameter}"'
 
     raise Exception('Error in "_convert_par_to_str": unrecognized type')
 
 
 def create_read_write_par(filename, parameters, ham_name):
     """Write subroutines read_parameters() and write_parameters_hdf5()."""
-    INDENT = 9     # Number of indentation spaces
+    INDENT = 9  # Number of indentation spaces
     LINE_MAX = 70  # Maximal line length
     TEMPLATE = """! This file is automatically generated by parse_ham.py
 ! Please note that all manual changes will be overwritten during compilation!
@@ -261,29 +260,30 @@ def create_read_write_par(filename, parameters, ham_name):
 #endif
 """
 
-    f = open(filename, 'w', encoding='UTF-8')
+    f = open(filename, "w", encoding="UTF-8")
     for line in TEMPLATE.splitlines(keepends=True):
-        if '##NAMELIST##' in line:
+        if "##NAMELIST##" in line:
             for nlist_name, nlist in parameters.items():
-                s = '{}NAMELIST /{}/  '.format(INDENT*' ', nlist_name)
+                s = f"{INDENT * ' '}NAMELIST /{nlist_name}/  "
                 for par_name in nlist:
-                    par_name = par_name.split('(')[0]
+                    par_name = par_name.split("(")[0]
                     if len(s) < LINE_MAX:
-                        s = '{}{}, '.format(s, par_name)
+                        s = f"{s}{par_name}, "
                     else:
-                        f.write('{}&\n'.format(s))
-                        s = '{}     &     {}, '.format(INDENT*' ', par_name)
-                f.write(s[:-2]+'\n')
-        elif '##PARAMETER_DEF##' in line:
+                        f.write(f"{s}&\n")
+                        s = f"{INDENT * ' '}     &     {par_name}, "
+                f.write(s[:-2] + "\n")
+        elif "##PARAMETER_DEF##" in line:
             for nlist_name, nlist in parameters.items():
-                f.write('{}!Parameters {}\n'.format(INDENT*' ', nlist_name))
+                f.write(f"{INDENT * ' '}!Parameters {nlist_name}\n")
 
                 names_len = _max_len(nlist)
                 # dtypes_str = [_dtype_name(par['value']) for
                 #               par_name, par in nlist.items()]
                 # dtypes_len = _max_len(dtypes_str)
-                pars_str = [_convert_par_to_str(par['value']) for
-                            par_name, par in nlist.items()]
+                pars_str = [
+                    _convert_par_to_str(par["value"]) for par_name, par in nlist.items()
+                ]
                 pars_len = _max_len(pars_str)
                 # comments = [par[1] for par_name, par in nlist.items()]
                 # for i in range(len(nlist)):
@@ -295,96 +295,83 @@ def create_read_write_par(filename, parameters, ham_name):
                     #     par_name.ljust(names_len),
                     #     _convert_par_to_str(par['value']).ljust(pars_len)
                     #     )
-                    s = '{}{} = {} !'.format(
-                        INDENT*' ',
-                        par_name.ljust(names_len),
-                        _convert_par_to_str(par['value']).ljust(pars_len)
-                        )
-                    comment = par['comment'].split(' ')
-                    comment_indent = min(40, len(s)-2)
+                    s = f"{INDENT * ' '}{par_name.ljust(names_len)} = {_convert_par_to_str(par['value']).ljust(pars_len)} !"
+                    comment = par["comment"].split(" ")
+                    comment_indent = min(40, len(s) - 2)
                     for word in comment:
                         if len(s) < LINE_MAX:
-                            s = '{} {}'.format(s, word)
+                            s = f"{s} {word}"
                         else:
-                            f.write('{} \n'.format(s))
-                            s = '{} ! {}'.format(comment_indent*' ', word)
+                            f.write(f"{s} \n")
+                            s = f"{comment_indent * ' '} ! {word}"
                     f.write(s)
-                    f.write('\n')
-        elif '##READ_VAR##' in line:
+                    f.write("\n")
+        elif "##READ_VAR##" in line:
             for nlist_name, nlist in parameters.items():
-                f.write('{}   REWIND(unit_para)\n'.format(INDENT*' '))
-                s = '{}   READ(unit_para, NML={})\n'.format(
-                    INDENT*' ', nlist_name)
-                f.write(s)
+                f.write(f"{INDENT * ' '}   REWIND(unit_para)\n")
+                f.write(f"{INDENT * ' '}   READ(unit_para, NML={nlist_name})\n")
 
-        elif '##MPI_BCAST##' in line:
-            fstring = '{}CALL MPI_BCAST({},{:>3},{},0,Group_Comm,ierr)\n'
+        elif "##MPI_BCAST##" in line:
             for nlist_name, nlist in parameters.items():
                 names_len = _max_len(nlist)
                 for par_name, par in nlist.items():
-                    s = fstring.format(
-                        INDENT*' ',
-                        par_name.split('(')[0].ljust(names_len),
-                        _get_mpi_len(par['value']),
-                        _get_mpi_dtype(par['value']),
-                        )
-                    f.write(s)
-        elif '##TEST_ATTRS##' in line:
+                    par_name_clean = par_name.split("(")[0].ljust(names_len)
+                    mpi_len = _get_mpi_len(par["value"])
+                    mpi_dtype = _get_mpi_dtype(par["value"])
+                    f.write(f"{INDENT * ' '}CALL MPI_BCAST({par_name_clean},{mpi_len:>3},{mpi_dtype},0,Group_Comm,ierr)\n")
+        elif "##TEST_ATTRS##" in line:
             for nlist_name, nlist in parameters.items():
-                s = """CALL h5lexists_f(group_id, "{}", link_exists, ierr)
+                nlist_lower = nlist_name.lower()
+                s = f"""CALL h5lexists_f(group_id, "{nlist_lower}", link_exists, ierr)
                        if ( .not. link_exists ) then
-                         call h5gcreate_f(group_id, "{}", group_id2, ierr)
+                         call h5gcreate_f(group_id, "{nlist_lower}", group_id2, ierr)
                          call h5gclose_f(group_id2, ierr)
-                       endif\n""".format(nlist_name.lower(), nlist_name.lower())
+                       endif\n"""
                 f.write(s)
                 for par_name, par in nlist.items():
-                    s = '{}call test_attribute(group_id, "{}", "{}", {}, ierr)\n'.format(
-                        INDENT*' ', nlist_name.lower(), par_name.lower(), par_name
-                        )
-                    f.write(s)
+                    f.write(f'{INDENT * " "}call test_attribute(group_id, "{nlist_lower}", "{par_name.lower()}", {par_name}, ierr)\n')
         else:
-            f.write(line.replace('##HAM_NAME##', ham_name))
+            f.write(line.replace("##HAM_NAME##", ham_name))
     f.close()
 
 
 def _to_value(dtype, value):
-    if 'real' in dtype:
-        return float(value.replace('d', 'e').replace('D', 'e'))
+    if "real" in dtype:
+        return float(value.replace("d", "e").replace("D", "e"))
     # if 'complex' in dtype:
     #     tmp = value.strip('()').split(',')
     #     if not len(tmp) == 2:
     #         raise Exception(
     #             '"{}", "{}" cannot be mapped to complex'.format(dtype, value))
     #     return complex(float(tmp[0]), float(tmp[1]))
-    if 'integer' in dtype:
+    if "integer" in dtype:
         return int(value)
-    if 'character' in dtype:
-        return value.strip('"\'')
-    if 'logical' in dtype:
-        if 't' in value or 'T' in value:
+    if "character" in dtype:
+        return value.strip("\"'")
+    if "logical" in dtype:
+        if "t" in value or "T" in value:
             return True
-        if 'f' in value or 'F' in value:
+        if "f" in value or "F" in value:
             return False
 
-        raise Exception(
-            '"{}" can not be mapped to bool.'.format(value))
+        raise Exception(f'"{value}" can not be mapped to bool.')
 
-    raise Exception('"{}" can not be mapped to a type'.format(dtype))
+    raise Exception(f'"{dtype}" can not be mapped to a type')
 
 
 def _get_mpi_dtype(parameter):
     if isinstance(parameter, list):
         return _get_mpi_dtype(parameter[0])
     if isinstance(parameter, bool):
-        return 'MPI_LOGICAL  '
+        return "MPI_LOGICAL  "
     if isinstance(parameter, float):
-        return 'MPI_REAL8    '
+        return "MPI_REAL8    "
     # if isinstance(parameter, complex):
     #     return 'MPI_COMPLEX16'
     if isinstance(parameter, int):
-        return 'MPI_INTEGER  '
+        return "MPI_INTEGER  "
     if isinstance(parameter, str):
-        return 'MPI_CHARACTER'
+        return "MPI_CHARACTER"
     raise Exception('Error in "_get_mpi_dtype": unrecognized type')
 
 

--- a/Prog/parse_ham_mod.py
+++ b/Prog/parse_ham_mod.py
@@ -45,7 +45,7 @@ def get_ham_names_ham_files(ham_list_file):
     for line in lines:
         ham_names.append(line[0])
         try:
-            ham_files.append(line[1])
+            ham_files.append(os.path.expandvars(line[1]))
         except IndexError:
             ham_files.append(
                 'Hamiltonians/Hamiltonian_{}_smod.F90'.format(line[0]))

--- a/Prog/parse_ham_mod.py
+++ b/Prog/parse_ham_mod.py
@@ -11,27 +11,30 @@ __author__ = "Jonas Schwab"
 __copyright__ = "Copyright 2022, The ALF Project"
 __license__ = "GPL"
 
-import glob
 import os
+from pathlib import Path
 
 
 def get_ham_names_ham_files(ham_list_file):
     """Return list of Hamiltonian names and files.
-    
+
     Also parses files in directory `ham_list_file` + '.d',
     so usually ${ALF_DIR}/Prog/Hamiltonians.list and files in
     ${ALF_DIR}/Prog/Hamiltonians.list.d
 
     If applicable, add any external Hamiltonians located at ${ALF_EXTRA_HAM_LIST}.
     """
-    ham_list_files = [ham_list_file, *glob.glob(ham_list_file + '.d/*')]
+
+    d_dir = Path(ham_list_file + '.d')
+    ham_list_files = [ham_list_file, *(d_dir.glob('*') if d_dir.is_dir() else [])]
 
     extra = os.environ.get('ALF_EXTRA_HAM_LIST')
     if extra:
-        if not os.path.isfile(extra):
+        extra_path = Path(extra)
+        if not extra_path.is_file():
             raise FileNotFoundError(
                 'ALF_EXTRA_HAM_LIST is set but file not found: {}'.format(extra))
-        ham_list_files.append(extra)
+        ham_list_files.append(extra_path)
 
     lines = []
     for file in ham_list_files:
@@ -45,11 +48,12 @@ def get_ham_names_ham_files(ham_list_file):
     for line in lines:
         ham_names.append(line[0])
         try:
-            ham_files.append(os.path.expandvars(line[1]))
+            ham_files.append(Path(os.path.expandvars(line[1])).resolve())
         except IndexError:
             ham_files.append(
-                'Hamiltonians/Hamiltonian_{}_smod.F90'.format(line[0]))
+                Path('Hamiltonians/Hamiltonian_{}_smod.F90'.format(line[0])).resolve())
     return ham_names, ham_files
+
 
 def parse(filename):
     """Parse Fortran file for parameter lists.


### PR DESCRIPTION
Currently there is no mechanism for linking a private Hamiltonian library to ALF. I propose a small modification to `parse_ham_mod.py` that would allow ALF to add additional Hamiltonians from an external list file located at environment variable `ALF_EXTRA_HAM_LIST`.

# Changes

- If `ALF_EXTRA_HAM_LIST` is set, `parse_ham_mod.py` will include Hamiltonians listed here in the program.
- Allow for expansion of environment variables when parsing Hamiltonian file locations.

# Safety

If the environment variable does not exist, the functionality of ALF is unchanged.