### PR TITLE
MaxEnt: Use scientific format when writing floats to file.

### DIFF
--- a/Analysis/Max_SAC.F90
+++ b/Analysis/Max_SAC.F90
@@ -46,6 +46,7 @@ Program MaxEnt_Wrapper
        Use MaxEnt_mod
        use MaxEnt_Wrapper_mod
        use iso_fortran_env, only: output_unit, error_unit
+       use Files_mod, only: str_to_upper
 #ifdef _OPENMP
        use check_omp_num_threads_mod
 #endif
@@ -125,9 +126,9 @@ Program MaxEnt_Wrapper
        dtau = Xtau(2) - Xtau(1)
        11 format(A20, ': ', A)
        12 format(A20, ': ', I10)
-       13 format(A20, ': ', *(F14.7))
+       13 format(A20, ': ', *(E25.17E3))
        14 format(A20, ': ', (L1))
-       15 format((E26.17E3))
+       15 format((E25.17E3))
 
        If (Stochastic) then 
           Open(unit=50,File='Info_MaxEnt',Status="unknown")
@@ -353,12 +354,12 @@ Program MaxEnt_Wrapper
                    Write(error_unit,*) "Channel '" // Channel // "' not yet implemented"
                    CALL Terminate_on_error(ERROR_MAXENT,__FILE__,__LINE__)
              end Select
-             Write(11,"(F14.7,2x,F14.7,2x,F14.7,2x,F14.7)")  xtau_st(nt), xqmc_st(nt),  sqrt(xcov_st(nt,nt)), xmom1*X
+             Write(11,"(E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)")  xtau_st(nt), xqmc_st(nt),  sqrt(xcov_st(nt,nt)), xmom1*X
           enddo
           close(11)
           N_alpha_1 = N_alpha - 10
           File1 ="Aom_ps"
-          file2 =File_i(File1,N_alpha_1)
+          write(file2, '(A,"_",I0)') trim(File1), N_alpha_1
           Open(Unit=66,File=file2,status="unknown")
           do nw = 1,Ndis
              read(66,*) xom(nw), A(nw), x, x1, x2
@@ -378,7 +379,7 @@ Program MaxEnt_Wrapper
              Do nw = 1,Ndis
                 X = X  +  A_classic(nw)*Xker_classic(nt,nw)
              enddo
-             Write(11,"(F14.7,2x,F14.7,2x,F14.7,2x,F14.7)")  xtau_st(nt), xqmc_st(nt),  sqrt(xcov_st(nt,nt)), X
+             Write(11,"(E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)")  xtau_st(nt), xqmc_st(nt),  sqrt(xcov_st(nt,nt)), X
           enddo
           close(11)
           Write(50,13) "Final value of  alpha ", 1.d0/Alpha_classic_st
@@ -446,10 +447,10 @@ Program MaxEnt_Wrapper
             x  = x  + Aimag(Z)
             x1 = x1 + om*Aimag(Z)
             x2 = x2 + om*om*Aimag(Z)
-            write(43,"('X',2x,F14.7,2x,F16.8,2x,F16.8,2x,F14.7,2x,F14.7,2x,F14.7)")  & 
+            write(43,"('X',2x,E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)")  & 
                & xom(nw), dble(Z), Aimag(Z),  X*dom, x1*dom, x2*dom
           else
-            write(43,"('X',2x,F14.7,2x,F16.8,2x,F16.8)")  & 
+            write(43,"('X',2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)")  & 
                & xom(nw), dble(Z), Aimag(Z)
           endif   
        enddo

--- a/Libraries/Modules/maxent_mod.F90
+++ b/Libraries/Modules/maxent_mod.F90
@@ -196,7 +196,7 @@ Module MaxEnt_mod
 
            CLOSE(44)
 
-2006       FORMAT('Res: 1/Alpha, XQ,S,CHI: ', F24.12,2x,F24.12,2x,F24.12,2x,F24.12)
+2006       FORMAT('Res: 1/Alpha, XQ,S,CHI: ', E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)
 
            ALPHA_ST =  ALPHA 
             DEALLOCATE ( XLAM, SIG1, COVM1, UC, DEF )
@@ -835,7 +835,7 @@ Module MaxEnt_mod
            CLOSE(44)
 
 
-2006       FORMAT('Res: Alpha, XQ,S,CHI: ', F14.7,2x,F14.7,2x,F14.7,2x,F14.7)
+2006       FORMAT('Res: Alpha, XQ,S,CHI: ', E25.17E3,2x,E25.17E3,2x,E25.17E3,2x,E25.17E3)
 
 
             DEALLOCATE ( XLAM, SIG1, COVM1, UC, DEF )

--- a/Libraries/Modules/maxent_stoch_mod.F90
+++ b/Libraries/Modules/maxent_stoch_mod.F90
@@ -46,7 +46,6 @@ Module MaxEnt_stoch_mod
        Use runtime_error_mod
        Use MyMats
        Use Random_Wrap
-       Use Files_mod
        use iso_fortran_env, only: output_unit, error_unit
 
        Integer, private :: NTAU, nt, Ngamma, ng, Ndis, nd,  L_seed
@@ -232,7 +231,7 @@ Module MaxEnt_stoch_mod
                  enddo
                  En_tot(ns) = En ! this is the energy of the configuration Xn_tot for simulation ns
                  Open (Unit=44,File='Max_stoch_log', Status="unknown", position="append")
-                 Write(44,2003) 1.d0/Alpha, En_m, Acc_1, Acc_2
+                Write(44,"('Alpha, En_m, Acc ', E25.17E3, 2x, E25.17E3, 2x, E25.17E3, 2x, E25.17E3, 2x, E25.17E3)") 1.d0/Alpha, En_m, Acc_1, Acc_2
                  close(44)
                  if (nb.gt.nwarm) then
                     if (ns.eq.1) nc = nc + 1
@@ -372,15 +371,14 @@ Module MaxEnt_stoch_mod
                     Mom_e_tot(n,ns) = 0.d0
                  endif
               enddo
-              write(66,"(F12.6,2x,F12.6,2x,F12.6,2x,F12.6,2x,F12.6,2x,F12.6,2x,F12.6,2x,F12.6,2x,F12.6)") &
-                   & Alpha_tot(ns), Mom_m_tot(1,ns), Mom_e_tot(1,ns), &
+              write(66,'(9(1X,E25.17E3))') Alpha_tot(ns), Mom_m_tot(1,ns), Mom_e_tot(1,ns), &
                    & Mom_m_tot(2,ns), Mom_e_tot(2,ns),Mom_m_tot(3,ns), Mom_e_tot(3,ns),  &
-                   & Mom_m_tot(4,ns), Mom_e_tot(4,ns) 
+                   & Mom_m_tot(4,ns), Mom_e_tot(4,ns)
            enddo
            close(66)
            File_root = "Aom"
            do ns = 1,Nsims
-              File1 = File_i(File_root,ns)
+              write(File1,'(A,"_",I0)') trim(File_root), ns
               Open(Unit=66,File=File1,status="unknown")
               do nd = 1,Ndis
                  Xn_m_tot(nd,ns) = Xn_m_tot(nd,ns) / dble(nc) ! * delta /(dble(nc)*pi)
@@ -394,7 +392,7 @@ Module MaxEnt_stoch_mod
                  om =  Om_st_1 + dble(nd-1)*Dom_spectral ! PhiM1(dble(nd)/dble(NDis)) HERE
                  Aom = Xn_m_tot(nd,ns) ! * Xmom1
                  Err = Xn_e_tot(nd,ns) ! * Xmom1
-                 write(66,2001) om, Back_Trans_Aom(Aom,om,Beta), Back_Trans_Aom(Err,om,Beta)
+                 write(66,'(3(1X,E25.17E3))') om, Back_Trans_Aom(Aom,om,Beta), Back_Trans_Aom(Err,om,Beta)
                  ! PhiM1(dble(nd)/dble(NDis)), Xn_m_tot(nd,ns)
               enddo
               Close(66)
@@ -414,7 +412,7 @@ Module MaxEnt_stoch_mod
                  Xn_m(nd) = Xn_m(nd) / (En_m_tot(p_star) - En_m_tot(NSims))
                  Xn_e(nd) = Xn_e(nd) / (En_m_tot(p_star) - En_m_tot(NSims))
               enddo
-              File1 = File_i(File_root,p_star)
+              write(File1,'(A,"_",I0)') trim(File_root), p_star
               Open(Unit=66,File=File1,status="unknown")
               XMAX = 0.d0
               Do nd = 1,Ndis
@@ -427,7 +425,7 @@ Module MaxEnt_stoch_mod
               enddo
               do nd = 1,Ndis
                  om =  Om_st_1 +  dble(nd-1)*Dom_spectral  !  PhiM1(dble(nd)/dble(NDis)) HERE
-                 write(66,2005) om, Xn_m(nd), Xn_e(nd), Xn_m(nd)/XMAX, Xn_e(nd)/XMAX
+                 write(66,'(5(1X,E25.17E3))') om, Xn_m(nd), Xn_e(nd), Xn_m(nd)/XMAX, Xn_e(nd)/XMAX
                  ! PhiM1(dble(nd)/dble(NDis)), Xn_m(nd)
               enddo
               close(66)
@@ -447,10 +445,6 @@ Module MaxEnt_stoch_mod
            DeAllocate( G_Mean )
            DeAllocate( xqmc1 )
            Deallocate( Xker_table )
-2001       format(F14.7,2x,F14.7,2x,F14.7)
-!2004       format(F14.7,2x,F14.7,2x,F14.7,2x,F14.7)
-2005       format(F14.7,2x,F14.7,2x,F14.7,2x,F14.7,2x,F14.7)
-2003       format('Alpha, En_m, Acc ', F14.7,2x,F24.12,2x,F14.7,2x,F14.7,2x,F14.7)
            
          end Subroutine MaxEnt_stoch
 !------------------------------------------------------------------------------------------------


### PR DESCRIPTION
MaxEnt currently uses fixed-format for writing floats to files. This can break in edge cases, so I propose switching to scientific notation.

**Changes:**
- Switched several `FORMAT` statements from fixed (`F`) to scientific (`E`/`ES`) in MaxEnt logging/output.
- Updated `Max_SAC` output formats to use scientific notation and added the missing `Files_mod` import for `str_to_upper`.
- Replaced `File_i()` usage with inline filename construction. Since `File_i()` is a one-liner anyway, this is in my opinion clearer and more robust.