### PR TITLE
Add configure.fish, a wrapper of configure.sh for fish shell.

### DIFF
--- a/configure.fish
+++ b/configure.fish
@@ -1,0 +1,33 @@
+#!/usr/bin/env fish
+# configure.fish - Fish shell wrapper for configure.sh
+#
+# Must be sourced so the exported variables take effect in your session:
+#   source configure.fish MACHINE [MODE] [STAB] [options]
+#   or: . configure.fish MACHINE [MODE] [STAB] [options]
+#
+# All arguments are forwarded verbatim to configure.sh.
+# See configure.sh for the full list of MACHINE, MODE, STAB, and option values.
+
+set -l _alf_dir (dirname (realpath (status --current-filename)))
+set -l _alf_env_file (mktemp 2>/dev/null; or mktemp -t alf_env)
+
+# Source configure.sh inside a POSIX sh subshell rooted at the ALF directory.
+# Normal output (progress messages, errors) passes through to the terminal.
+# On success, the resulting environment is dumped to a temp file.
+sh -c 'cd "$1" && _alf_env_file="$2" && shift 2 && . ./configure.sh "$@" && env > "$_alf_env_file"' -- "$_alf_dir" "$_alf_env_file" $argv
+set -l _alf_exit $status
+
+if test $_alf_exit -ne 0
+    rm -f $_alf_env_file
+    return $_alf_exit
+end
+
+# Import every ALF_* variable that configure.sh exported into the fish session.
+for _alf_line in (grep '^ALF_' $_alf_env_file)
+    set -l _alf_kv (string split -m 1 '=' -- $_alf_line)
+    if test (count $_alf_kv) -eq 2
+        set -gx $_alf_kv[1] $_alf_kv[2]
+    end
+end
+
+rm -f $_alf_env_file

--- a/configure.fish
+++ b/configure.fish
@@ -8,6 +8,18 @@
 # All arguments are forwarded verbatim to configure.sh.
 # See configure.sh for the full list of MACHINE, MODE, STAB, and option values.
 
+# Ensure this script is sourced inside a Fish shell, not executed directly or
+# sourced from a different shell (e.g. bash/sh).
+if not set -q FISH_VERSION
+    printf "Error: configure.fish must be sourced inside a Fish shell session.\n" >&2
+    exit 1
+end
+if not status --is-interactive
+    printf "Error: configure.fish must be sourced, not executed directly.\n" >&2
+    printf "  Use: source configure.fish MACHINE [MODE] [STAB] [options]\n" >&2
+    exit 1
+end
+
 set -l _alf_dir (dirname (realpath (status --current-filename)))
 set -l _alf_env_file (mktemp 2>/dev/null; or mktemp -t alf_env)
 

--- a/configure.fish
+++ b/configure.fish
@@ -12,12 +12,12 @@
 # sourced from a different shell (e.g. bash/sh).
 if not set -q FISH_VERSION
     printf "Error: configure.fish must be sourced inside a Fish shell session.\n" >&2
-    exit 1
+    return 1
 end
 if not status --is-interactive
     printf "Error: configure.fish must be sourced, not executed directly.\n" >&2
     printf "  Use: source configure.fish MACHINE [MODE] [STAB] [options]\n" >&2
-    exit 1
+    return 1
 end
 
 set -l _alf_dir (dirname (realpath (status --current-filename)))


### PR DESCRIPTION
Adds a Fish shell wrapper around `configure.sh` so Fish users can set up the ALF build environment by sourcing a Fish script, while still reusing the existing POSIX `configure.sh` logic.

## Changes

- Introduces `configure.fish` to invoke `configure.sh` in a POSIX `sh` subshell, using portable `mktemp` fallback for BSD/macOS compatibility.
- Passes paths as positional parameters to `sh -c` to correctly handle spaces and special characters.
- Captures the resulting environment and imports `ALF_*` variables into the current Fish session.
- Guards against incorrect usage: errors with a clear message if the script is not sourced inside an interactive Fish shell session (e.g. executed directly or sourced from bash/sh).

## Usage

```fish
source configure.fish MACHINE [MODE] [STAB] [options]
# or
. configure.fish MACHINE [MODE] [STAB] [options]
```

See `configure.sh` for the full list of `MACHINE`, `MODE`, `STAB`, and option values.