### PR TITLE
GitLab CI: Set artifacts to expire after 7 days

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 default:
   tags: [k8s]
+  artifacts:
+    expire_in: 7 days
 
 stages:
   - lint


### PR DESCRIPTION
Just a trivial change in the GitLab CI config to keep GitLab storage from clutter.