### PR TITLE
Stop at whichever of NBin or CPU_MAX comes first

### DIFF
--- a/.github/actions/alf_test/action.yml
+++ b/.github/actions/alf_test/action.yml
@@ -69,6 +69,18 @@ runs:
           "$ALF_DIR/Analysis/ana.out" *
         fi
 
+    - name: NBin/CPU_MAX bound test
+      shell: bash
+      env:
+        ARGS: ${{ inputs.args }}
+      run: |
+        . ./configure.sh $ARGS
+        # Runs the binary directly and reads data.h5, so noMPI with HDF5 only.
+        if ! echo "$MODE" | grep -iq -e "serial" -e "noMPI"; then exit 0; fi
+        if ! echo "$CONFIG_ARGS" | grep -iq "HDF5"; then exit 0; fi
+        python3 -c "import h5py" 2>/dev/null || pip install --quiet h5py
+        python3 "$ALF_DIR/testsuite/test_nbin_cpu_max.py"
+
     - name: Run unit tests
       shell: bash
       env:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,12 @@ test:
       else 
         "$ALF_DIR/Analysis/ana.out" *;
       fi
+    # Runs the binary directly and reads data.h5, so noMPI with HDF5 only.
+    - if echo "$MODE" | grep -iq -e "serial" -e "noMPI" &&
+         echo "$CONFIG_ARGS" | grep -iq "HDF5"; then
+        python3 -c "import h5py" 2>/dev/null || pip install --quiet h5py;
+        python3 "$ALF_DIR/testsuite/test_nbin_cpu_max.py";
+      fi
     - mkdir "$ALF_DIR/testsuite/tests"
     - cd "$ALF_DIR/testsuite/tests"
     - if echo $ALF_FC | grep -q "mpiifort -fc=ifx"; then exit 0; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Log of backward compatibility changes and critical bugs
 
+### 2026-09-02 NBin and CPU_MAX are both bounds
+Author: A. Gavrishev <br>
+[GitHub](https://github.com/ALF-QMC/ALF/pull/XXX)
+
+Previously when a non-zero `CPU_MAX` was set, any `NBin` setting was discarded outright. Now, both are simulation bounds and the run stops at whichever is reached first; this makes the use of checkpoint restarting when limited by wall-time easier as it is straightforward to set an overall bin count target that simulations must eventually reach. `NBin <= 0` keeps the purely time-bounded behaviour.
+
+A run that sets both `NBin > 0` and `CPU_MAX > 0` and previously relied on `CPU_MAX` switching the Nbin target "off" must now explicitly
+set `NBin = 0`.
+
+The `info` file now reports both bounds, adding a `Bins` or `No bin-number limitation` line. Any
+code that parses `info` by line position rather than by key has to be slightly adapted.
+
 ### 2026-01-28 factors of pi in analytical continuation
 Author F. Assaad <br>
 Merge request [!257](https://git.physik.uni-wuerzburg.de/ALF/ALF/-/merge_requests/257) | [GitHub](https://github.com/ALF-QMC/ALF/issues/587)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2026-09-02 NBin and CPU_MAX are both bounds
 Author: A. Gavrishev <br>
-[GitHub](https://github.com/ALF-QMC/ALF/pull/XXX)
+[GitHub](https://github.com/ALF-QMC/ALF/pull/648)
 
 Previously when a non-zero `CPU_MAX` was set, any `NBin` setting was discarded outright. Now, both are simulation bounds and the run stops at whichever is reached first; this makes the use of checkpoint restarting when limited by wall-time easier as it is straightforward to set an overall bin count target that simulations must eventually reach. `NBin <= 0` keeps the purely time-bounded behaviour.
 

--- a/Documentation/files.tex
+++ b/Documentation/files.tex
@@ -95,8 +95,9 @@ NBin                 = 5    ! Number of bins
 Ltau                 = 1    ! 1 to calculate time-displaced Green functions; 0 otherwise
 LOBS_ST              = 0    ! Start measurements at time slice LOBS_ST
 LOBS_EN              = 0    ! End measurements at time slice LOBS_EN
-CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours, if 0 or not
-                            ! specified, the code stops after Nbin bins
+CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours or NBin bins,
+                            ! whichever comes first. If 0 or not specified,
+                            ! the code stops after NBin bins
 Propose_S0           = .F.  ! Proposes single spin flip moves with probability exp(-S0) 
 Global_moves         = .F.  ! Allows for global moves in space and time 
 N_Global             = 1    ! Number of global moves per sweep 

--- a/Prog/default_parameters_generic.py
+++ b/Prog/default_parameters_generic.py
@@ -10,9 +10,9 @@ from collections import OrderedDict
 # Generic (Hamiltonian independent) ALF parameters with default values.
 _PARAMS_GENERIC = OrderedDict([
     ('VAR_QMC',
-        {'CPU_MAX': {'comment': 'Code stops after CPU_MAX hours, if 0 or '
-                                'not specified, the code stops after '
-                                'Nbin bins',
+        {'CPU_MAX': {'comment': 'Code stops after CPU_MAX hours or NBin '
+                                'bins, whichever comes first. If 0 or not '
+                                'specified, the code stops after NBin bins',
                      'value': 0.0},
          'Delta_t_Langevin_HMC': {'comment': 'Time step for Langevin or '
                                              'HMC',

--- a/Prog/main.F90
+++ b/Prog/main.F90
@@ -72,9 +72,11 @@
 !> \endverbatim
 !> @param CPU_MAX Real
 !> \verbatim
-!>  Available Wallclock time. The program will carry as many bins as
-!>  possible during this time
-!>  If not specified the program will stop after NBIN bins are calculated
+!>  Available Wallclock time.
+!>  The run stops at whichever bound comes first: NBIN bins, or this
+!>  wallclock time. With NBIN <= 0 the wallclock time is the only bound and
+!>  the program carries as many bins as possible during it; with CPU_MAX not
+!>  specified NBIN is the only bound.
 !> \endverbatim
 !> @param Propose_S0 Logical
 !> \verbatim
@@ -188,7 +190,7 @@ Program Main
         CLASS(UDV_State), Dimension(:,:), ALLOCATABLE :: udvst
 
         ! For the truncation of the program:
-        logical                   :: prog_truncation, run_file_exists
+        logical                   :: prog_truncation, run_file_exists, NBin_bounded
         integer (kind=kind(0.d0)) :: count_bin_start, count_bin_end
         
         ! For MPI shared memory
@@ -410,7 +412,10 @@ Program Main
         endif
         Call Hop_mod_init
 
-        IF (ABS(get_CPU_MAX()) > Zero ) call set_NBin(10000000)
+        ! Both are bounds; the run stops at whichever comes first. The sentinel
+        ! lifts the bin bound only when NBin is unset.
+        NBin_bounded = get_NBin() > 0
+        IF (ABS(get_CPU_MAX()) > Zero .AND. .NOT. NBin_bounded ) call set_NBin(10000000)
         If (get_N_Global_tau() > 0) then
            Call Wrapgr_alloc
         endif
@@ -492,8 +497,14 @@ Program Main
 #endif
            Open (Unit = 50,file=file_info,status="unknown",position="append")
            Write(50,*) 'Sweeps                              : ', get_NSweep()
-           If ( abs(get_CPU_MAX()) < ZERO ) then
+           ! NBin_bounded, not get_NBin(), so the sentinel is never printed as
+           ! a requested bin count.
+           If ( NBin_bounded ) then
               Write(50,*) 'Bins                                : ', get_NBin()
+           else
+              Write(50,*) 'No bin-number limitation '
+           endif
+           If ( abs(get_CPU_MAX()) < ZERO ) then
               Write(50,*) 'No CPU-time limitation '
            else
               Write(50,'(" Prog will stop after hours:",2x,F8.4)') get_CPU_MAX()

--- a/Scripts_and_Parameters_files/Start/parameters
+++ b/Scripts_and_Parameters_files/Start/parameters
@@ -35,8 +35,9 @@ NBin                 = 5    ! Number of bins
 Ltau                 = 1    ! 1 to calculate time-displaced Green functions; 0 otherwise
 LOBS_ST              = 0    ! Start measurements at time slice LOBS_ST
 LOBS_EN              = 0    ! End measurements at time slice LOBS_EN
-CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours, if 0 or not
-                            ! specified, the code stops after Nbin bins
+CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours or NBin bins,
+                            ! whichever comes first. If 0 or not specified,
+                            ! the code stops after NBin bins
 Propose_S0           = .F.  ! Proposes single spin flip moves with probability exp(-S0) 
 Global_moves         = .F.  ! Allows for global moves in space and time 
 N_Global             = 1    ! Number of global moves per sweep 

--- a/Scripts_and_Parameters_files/Start_Tempering/Temp_0/parameters
+++ b/Scripts_and_Parameters_files/Start_Tempering/Temp_0/parameters
@@ -35,8 +35,9 @@ NBin                 = 5    ! Number of bins
 Ltau                 = 1    ! 1 to calculate time-displaced Green functions; 0 otherwise
 LOBS_ST              = 0    ! Start measurements at time slice LOBS_ST
 LOBS_EN              = 0    ! End measurements at time slice LOBS_EN
-CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours, if 0 or not
-                            ! specified, the code stops after Nbin bins
+CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours or NBin bins,
+                            ! whichever comes first. If 0 or not specified,
+                            ! the code stops after NBin bins
 Propose_S0           = .F.  ! Proposes single spin flip moves with probability exp(-S0) 
 Global_moves         = .F.  ! Allows for global moves in space and time 
 N_Global             = 1    ! Number of global moves per sweep 

--- a/Scripts_and_Parameters_files/Start_Tempering/Temp_1/parameters
+++ b/Scripts_and_Parameters_files/Start_Tempering/Temp_1/parameters
@@ -35,8 +35,9 @@ NBin                 = 5    ! Number of bins
 Ltau                 = 1    ! 1 to calculate time-displaced Green functions; 0 otherwise
 LOBS_ST              = 0    ! Start measurements at time slice LOBS_ST
 LOBS_EN              = 0    ! End measurements at time slice LOBS_EN
-CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours, if 0 or not
-                            ! specified, the code stops after Nbin bins
+CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours or NBin bins,
+                            ! whichever comes first. If 0 or not specified,
+                            ! the code stops after NBin bins
 Propose_S0           = .F.  ! Proposes single spin flip moves with probability exp(-S0) 
 Global_moves         = .F.  ! Allows for global moves in space and time 
 N_Global             = 1    ! Number of global moves per sweep 

--- a/Scripts_and_Parameters_files/Start_Tempering/parameters
+++ b/Scripts_and_Parameters_files/Start_Tempering/parameters
@@ -35,8 +35,9 @@ NBin                 = 5    ! Number of bins
 Ltau                 = 1    ! 1 to calculate time-displaced Green functions; 0 otherwise
 LOBS_ST              = 0    ! Start measurements at time slice LOBS_ST
 LOBS_EN              = 0    ! End measurements at time slice LOBS_EN
-CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours, if 0 or not
-                            ! specified, the code stops after Nbin bins
+CPU_MAX              = 0.0  ! Code stops after CPU_MAX hours or NBin bins,
+                            ! whichever comes first. If 0 or not specified,
+                            ! the code stops after NBin bins
 Propose_S0           = .F.  ! Proposes single spin flip moves with probability exp(-S0) 
 Global_moves         = .F.  ! Allows for global moves in space and time 
 N_Global             = 1    ! Number of global moves per sweep 

--- a/testsuite/test_nbin_cpu_max.py
+++ b/testsuite/test_nbin_cpu_max.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""NBin and CPU_MAX are both bounds; the run stops at whichever comes first.
+
+Runs the Start parameter set with several (NBin, CPU_MAX) pairs and checks the
+bins actually written to data.h5. Needs a binary built with HDF5, and runs it
+directly, so noMPI:
+
+    . configure.sh GNU noMPI HDF5 && make program
+    ./testsuite/test_nbin_cpu_max.py
+
+Exits non-zero on the first failed check.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import h5py
+
+ALF_DIR = Path(__file__).resolve().parent.parent
+ALF_BIN = ALF_DIR / "Prog" / "ALF.out"
+START_DIR = ALF_DIR / "Scripts_and_Parameters_files" / "Start"
+
+SMALL = {
+    "VAR_lattice": {"L1": 4, "L2": 4},
+    "VAR_QMC": {"NSweep": 20, "Ltau": 0},
+}
+
+
+def rewrite_parameters(path, overrides):
+    """Rewrite ``key = value`` lines of path, per namelist."""
+    namelist = None
+    out = []
+
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("&"):
+            namelist = stripped[1:].split()[0]
+        elif stripped.startswith("/"):
+            namelist = None
+        elif "=" in line and namelist in overrides:
+            key = line.split("=", 1)[0].strip()
+            for want, value in overrides[namelist].items():
+                if key.lower() == want.lower():
+                    line = f"{key:<20} = {value}"
+                    break
+        out.append(line)
+    path.write_text("\n".join(out) + "\n")
+
+
+def run_alf(run_dir, nbin, cpu_max):
+    """Run ALF once in run_dir and return the bins in data.h5."""
+    if not run_dir.exists():
+        shutil.copytree(START_DIR, run_dir)
+    rewrite_parameters(
+        run_dir / "parameters",
+        {
+            "VAR_lattice": dict(SMALL["VAR_lattice"]),
+            "VAR_QMC": {**SMALL["VAR_QMC"], "NBin": nbin, "CPU_MAX": f"{cpu_max}d0"},
+        },
+    )
+    subprocess.run([str(ALF_BIN)], cwd=run_dir, check=True, timeout=900)
+    with h5py.File(run_dir / "data.h5", "r") as f:
+        return int(f["Ener_scal/obser"].shape[0])  # just use energy for bin count
+
+
+def check(name, ok, detail):
+    print(f"{'PASS' if ok else 'FAIL'}  {name}: {detail}")
+    return ok
+
+
+def main():
+    # check binary
+    if not ALF_BIN.exists():
+        sys.exit(f"{ALF_BIN} not built; run `make program` first")
+
+    results = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        # A reachable NBin must be honoured exactly. The time budget here is far
+        # larger than the work, so an implementation that lets CPU_MAX discard
+        # NBin runs the full budget and overshoots.
+        bins = run_alf(tmp / "bin_bound", nbin=20, cpu_max=0.05)
+        results.append(check("bin bound honoured", bins == 20, f"{bins} bins, want 20"))
+
+        # A tiny budget must truncate cleanly, well short of NBin. This is the
+        # graceful stop a checkpoint restart depends on, for example.
+        bins = run_alf(tmp / "time_bound", nbin=1_000_000, cpu_max=0.003)
+        results.append(
+            check("time bound truncates", 0 < bins < 1_000_000, f"{bins} bins")
+        )
+
+        # NBin <= 0 leaves the run bounded by time alone.
+        bins = run_alf(tmp / "no_bin_bound", nbin=0, cpu_max=0.003)
+        results.append(check("NBin <= 0 is time-bounded", bins > 0, f"{bins} bins"))
+
+        # NBin bounds this run alone; data.h5 accumulates across restarts.
+        restart = tmp / "restart"
+        bins = run_alf(restart, nbin=10, cpu_max=0.05)
+        results.append(check("restart, first leg", bins == 10, f"{bins} bins, want 10"))
+
+        # confout -> confin rename
+        promoted = list(restart.glob("confout_*"))
+        if not promoted:
+            sys.exit("no checkpoint to promote")
+        for conf in promoted:
+            conf.rename(restart / f"confin_{conf.name[len('confout_') :]}")
+        bins = run_alf(restart, nbin=5, cpu_max=0.05)
+
+        # Check that we get the right total after the restart run
+        results.append(
+            check("restart, second leg", bins == 15, f"{bins} bins, want 15")
+        )
+
+    if not all(results):
+        sys.exit(1)
+    print(f"{len(results)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've been using checkpoint restarting for my workflow and have found the following small modification to be useful. Currently any non-zero `CPU_MAX` completely discards any `NBin` entries, so this makes setting an overall `NBin` target for a checkpoint restart workflow cumbersome when there are wall time constraints and the runtime is not yet known. Instead one can bound the simulation by both `NBin` and `CPU_MAX`, taking the end criterion to be whichever comes first. `NBin <= 0` keeps the previous behaviour of being purely time-bounded.

## Safety

This is a behaviour change only for runs that set both, but otherwise backwards compatible. The `info` file now reports both bounds, adding just one line.

## Testing

I've added a short test, `testsuite/test_nbin_cpu_max.py`, to cover the bin bound, the time bound, `NBin <= 0` and a restart. This is added into the GitHub and GitLab test scripts for noMPI + HDF5 builds.
